### PR TITLE
Add word boundaries to regular expression to fix name matching error.

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,7 +102,7 @@ CacheBuster.prototype.references = function references() {
             var original = mappings[i].original;
             var cachebusted = mappings[i].cachebusted;
 
-            contents = contents.replace(new RegExp(original, 'g'), cachebusted);
+            contents = contents.replace(new RegExp('\\b' + original + '\\b', 'g'), cachebusted);
         }
 
         file.contents = new Buffer(contents, encoding);


### PR DESCRIPTION
This fixes an issue in which file names are being matched incorrectly. For example, "b.css" would also incorrectly match "a_b.css" because the regex doesn't specify the word boundary. 
