### PR TITLE
Call hash.end() after piping file through it

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,6 +24,7 @@ CacheBuster.prototype.getChecksum = function getChecksum(file) {
 
     if (file.isStream()) {
         file.pipe(hash);
+        hash.end();
     }
 
     if (file.isBuffer()) {


### PR DESCRIPTION
Fixes the following error when using browserify:

```
node_modules/gulp-cachebust/index.js:34
    return hash.read().toString('hex').substr(0, this.checksumLength);
                       ^
TypeError: Cannot call method 'toString' of null
  at CacheBuster.getChecksum (/Users/vast/src/beta.shkshk.ru/node_modules/gulp-cachebust/index.js:34:24)
  at CacheBuster.getBustedPath (/Users/vast/src/beta.shkshk.ru/node_modules/gulp-cachebust/index.js:38:25)
```

gulp task:

``` coffee
bundler = browserify(entries: ["./" + app_config.paths.main_javascript], extenstions: [".coffee"])

gulp.task "javascripts", ["clean:javascripts"], ->
  bundler.bundle()
    .pipe(source("application.js"))
    .pipe(cachebuster.resources())
    .pipe(gulp.dest(app_config.buildpaths.assets))

```
