### PR TITLE
Allow paths relative to a resource in a subpath.

### DIFF
--- a/index.js
+++ b/index.js
@@ -100,9 +100,9 @@ CacheBuster.prototype.references = function references() {
 
 
         var relativeRegex = null;
-        var pathComponents = path.parse(file);
-        if(pathComponents && pathComponents.dir){
-            relativeRegex = new RegExp(pathComponent.dir, 'g');
+        var pathComponents = path.parse(file.relative);
+        if(pathComponents && pathComponents.dir && pathComponents.dir!==""){
+            relativeRegex = new RegExp(pathComponents.dir, 'g');
         }
 
         var mappings = cachebuster.getRelativeMappings(file.path);

--- a/index.js
+++ b/index.js
@@ -98,10 +98,25 @@ CacheBuster.prototype.references = function references() {
 
         var contents = file.contents.toString(encoding);
 
+
+        var relativeRegex = null;
+        var lastIndexOfPathSeperator = file.relative.lastIndexOf("/");
+        if(lastIndexOfPathSeperator > -1){
+            var relativePath = file.relative.substring(0, file.relative.lastIndexOf("/")+1);
+            relativeRegex = new RegExp(relativePath, 'g');
+        }
+
         var mappings = cachebuster.getRelativeMappings(file.path);
         for (var i=0; i < mappings.length; i++) {
             var original = mappings[i].original;
             var cachebusted = mappings[i].cachebusted;
+
+            //if the contents is on a sub path, and the mapping is relative from there,
+            //we need to remove the subpath of the file being mapped, since it will not match the resource
+            if(relativeRegex){
+                original = original.replace(relativeRegex, "");
+                cachebusted = cachebusted.replace(relativeRegex, "");
+            }
 
             contents = contents.replace(new RegExp('\\b' + original + '(?!\\.)\\b', 'g'), cachebusted);
         }

--- a/index.js
+++ b/index.js
@@ -100,10 +100,9 @@ CacheBuster.prototype.references = function references() {
 
 
         var relativeRegex = null;
-        var lastIndexOfPathSeperator = file.relative.lastIndexOf("/");
-        if(lastIndexOfPathSeperator > -1){
-            var relativePath = file.relative.substring(0, file.relative.lastIndexOf("/")+1);
-            relativeRegex = new RegExp(relativePath, 'g');
+        var pathComponents = path.parse(file);
+        if(pathComponents && pathComponents.dir){
+            relativeRegex = new RegExp(pathComponent.dir, 'g');
         }
 
         var mappings = cachebuster.getRelativeMappings(file.path);


### PR DESCRIPTION
if the contents is on a sub path, and the mapping is relative from there, like a CSS file including a font in a sub dir, we need to remove the subpath of the file being mapped, since it will not match the resource
