### PR TITLE
Fixing the path mapping issue for windows which uses backslash.

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ var crypto = require('crypto');
 var through2 = require('through2');
 var gutil = require('gulp-util');
 var path = require('path');
+var slash = require('slash');
 var PluginError = gutil.PluginError;
 
 module.exports = CacheBuster;
@@ -45,7 +46,8 @@ CacheBuster.prototype.getBustedPath = function getBustedPath(file) {
     var basename = path.basename(file.path, extname);
     var dirname = path.dirname(file.path);
 
-    return path.join(dirname, basename + '.' + checksum + extname);
+    var str = path.join(dirname, basename + '.' + checksum + extname);
+    return slash(str);
 };
 
 CacheBuster.prototype.getRelativeMappings = function getRelativeMappings() {
@@ -71,10 +73,10 @@ CacheBuster.prototype.resources = function resources() {
             return callback();
         }
 
-        var original = file.relative;
+        var original = slash(file.relative);
         file.path = bustedPath;
 
-        cachebuster.mappings[original] = file.relative;
+        cachebuster.mappings[original] = slash(file.relative);
 
         this.push(file);
         return callback();

--- a/package.json
+++ b/package.json
@@ -7,6 +7,6 @@
   "dependencies": {
     "through2": "^0.5.1",
     "gulp-util": "^3.0.0",
-	"slash": "1.0.0"
+    "slash": "1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "repository": "git@github.com:Josiah/gulp-cachebust.git",
   "dependencies": {
     "through2": "^0.5.1",
-    "gulp-util": "^3.0.0"
+    "gulp-util": "^3.0.0",
+	"slash": "1.0.0"
   }
 }


### PR DESCRIPTION
While running cachebust on windows environment, it creates mapping with original and cachebusted resources but uses backslash in the key as well as value. Since most of the CSS and javascripts refer the references using forward slash in the path, replacement fails.
Ex - The mapping created on windows for resources
```javascript
{
    'background.png': 'background.d09952e7.png',
    'connect_logo.svg': 'connect_logo.ed8082c7.svg',
    'icons\ic_hamburger.svg': 'icons\\ic_hamburger.acc70e35.svg',
    'icons\ic_person_outline_24px.svg': 'icons\\ic_person_outline_24px.4ec40b8e.svg',
    'icons\ic_search_24px.svg': 'icons\\ic_search_24px.0cbd1d7d.svg'
}
```

In CSS, the image being referred as 
```javascript
  background: url("../images/icons/ic_hamburger.svg") center center no-repeat;
```
Slash makes the path consistent and hence generates the correct mappings
```javascript
{
    'background.png': 'background.d09952e7.png',
    'connect_logo.svg': 'connect_logo.ed8082c7.svg',
    'icons/ic_hamburger.svg': 'icons/ic_hamburger.acc70e35.svg',
    'icons/ic_person_outline_24px.svg': 'icons/c_person_outline_24px.4ec40b8e.svg',
    'icons/ic_search_24px.svg': 'icons/ic_search_24px.0cbd1d7d.svg'
}
```