### PR TITLE
added the option of generating checksums using sha1

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,16 @@ gulp.task('build-html', ['build-css'], function () {
 Type: `Number`
 Default: 8
 
+#### options.random
+
+Generates the checksum based on a random sha1 hash and not on the file contents.  
+Useful for changing the file names on each deploy regardless if the content was changed or not.  
+
+*Optional*  
+
+Type: `Boolean`
+Default: false
+
 ### CacheBuster.resources()
 
 Renames and collects resources according to their MD5 checksum.

--- a/index.js
+++ b/index.js
@@ -13,6 +13,12 @@ function CacheBuster(options) {
     }
 
     this.checksumLength = (options && options.checksumLength) || 8;
+    this.random = (options && options.random) || false;
+    if (this.random) {
+        var shasum = crypto.createHash('sha1');
+        shasum.update(crypto.randomBytes(50).toString());
+        this.hash =  shasum.digest('hex').substr(0, this.checksumLength);
+    }
     this.mappings = {};
 }
 
@@ -36,7 +42,7 @@ CacheBuster.prototype.getChecksum = function getChecksum(file) {
 }
 
 CacheBuster.prototype.getBustedPath = function getBustedPath(file) {
-    var checksum = this.getChecksum(file);
+    var checksum = this.random ? this.hash : this.getChecksum(file);
 
     if (!checksum) {
         return file.path;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "name": "gulp-cachebust",
   "description": "Generates checksums and renames references to files, useful for cachebusting",
-  "version": "0.0.5",
+  "version": "0.0.6",
+  "license": "MIT",
   "author": "Josiah <josiah@web-dev.com.au>",
   "repository": "git@github.com:Josiah/gulp-cachebust.git",
   "dependencies": {


### PR DESCRIPTION
Hi,

I had a problem that many times gulp-cachebust generated the same file names (checksums) for my files, even when I was actually doing code changes.
I added an option to just use random strings generated with sha1.
This makes sure that each time you run gulp-cachebust it will generate different file names.
The idea for using sha1 instead of crypto was taken from here:
http://stackoverflow.com/a/13254774/203292

This option is disabled by default.

Thanks.