### PR TITLE
added support for custom path formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,26 @@ Useful for changing the file names on each deploy regardless if the content was 
 Type: `Boolean`
 Default: false
 
+#### options.pathFormatter
+
+Specify a custom formatting function for busted paths. The default will output
+filenames like `/path/to/basename.[hash].ext`.
+
+*Optional*
+
+Type: `Function`
+Default: null
+
+An example for outputing a custom hash prefix:
+
+```js
+{
+    pathFormatter: function(dirname, basename, extname, checksum) {
+        return require('path').join(dirname, basename + '._v' + checksum + extname);
+    }
+}
+```
+
 ### CacheBuster.resources()
 
 Renames and collects resources according to their MD5 checksum.

--- a/index.js
+++ b/index.js
@@ -19,6 +19,11 @@ function CacheBuster(options) {
         shasum.update(crypto.randomBytes(50).toString());
         this.hash =  shasum.digest('hex').substr(0, this.checksumLength);
     }
+
+    this.pathFormatter = options && options.pathFormatter ? options.pathFormatter : function(dirname, basename, extname, checksum) {
+        return path.join(dirname, basename + '.' + checksum + extname);
+    };
+
     this.mappings = {};
 }
 
@@ -52,8 +57,7 @@ CacheBuster.prototype.getBustedPath = function getBustedPath(file) {
     var basename = path.basename(file.path, extname);
     var dirname = path.dirname(file.path);
 
-    var str = path.join(dirname, basename + '.' + checksum + extname);
-    return slash(str);
+    return slash(this.pathFormatter(dirname, basename, extname, checksum));
 };
 
 CacheBuster.prototype.getRelativeMappings = function getRelativeMappings() {


### PR DESCRIPTION
i thought it might be useful to be able to control the format of the cachebusted files (eg add a custom prefix to the bust hash). i needed this myself to be able to target busted files accurately from "cleaning" gulp tasks
