### PR TITLE
Added unit tests for simple methods.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,18 @@
   "license": "MIT",
   "author": "Josiah <josiah@web-dev.com.au>",
   "repository": "git@github.com:Josiah/gulp-cachebust.git",
+  "scripts": {
+    "test": "node_modules/.bin/mocha"
+  },
   "dependencies": {
     "through2": "^0.5.1",
     "gulp-util": "^3.0.0",
     "slash": "1.0.0"
+  },
+  "devDependencies": {
+    "chai": "^3.4.1",
+    "lodash": "^3.10.1",
+    "mocha": "^2.3.4",
+    "vinyl": "^1.1.0"
   }
 }

--- a/test/checksum.js
+++ b/test/checksum.js
@@ -1,6 +1,7 @@
+/*jshint mocha:true, expr: true */
 var CacheBuster = require('../index');
 var File = require('vinyl');
-var ReadableStream = require('stream').Readable
+var ReadableStream = require('stream').Readable;
 var expect = require('chai').expect;
 
 function createBufferFile(filename, content) {
@@ -41,8 +42,6 @@ describe('checksum generator', function () {
             var file2 = createBufferFile('file2', 'content2');
             var checksum1 = bust.getChecksum(file1);
             var checksum2 = bust.getChecksum(file2);
-            //console.log('checksum1: ' + checksum1);
-            //console.log('checksum2: ' + checksum2);
             // Sanity checks
             expect(file1.isBuffer()).to.be.true;
             expect(file2.isBuffer()).to.be.true;
@@ -59,8 +58,6 @@ describe('checksum generator', function () {
             var file2 = createStreamFile('file2', 'content2');
             var checksum1 = bust.getChecksum(file1);
             var checksum2 = bust.getChecksum(file2);
-            //console.log('checksum1: ' + checksum1);
-            //console.log('checksum2: ' + checksum2);
             // Sanity checks
             expect(file1.isBuffer()).to.be.false;
             expect(file2.isBuffer()).to.be.false;

--- a/test/checksum.js
+++ b/test/checksum.js
@@ -1,0 +1,79 @@
+var CacheBuster = require('../index');
+var File = require('vinyl');
+var ReadableStream = require('stream').Readable
+var expect = require('chai').expect;
+
+function createBufferFile(filename, content) {
+    var contentBuffer = new Buffer(content);
+    return new File({
+          cwd: '/',
+          base: '/test/',
+          path: '/test/' + filename,
+          contents: contentBuffer
+    });
+}
+
+function createStreamFile(filename, content) {
+    var contentStream = ReadableStream({objectMode: true});
+    contentStream.push(content);
+    contentStream.push(null);
+    return new File({
+          cwd: '/',
+          base: '/test/',
+          path: '/test/' + filename,
+          contents: contentStream
+    });
+}
+
+
+
+describe('checksum generator', function () {
+    var bust;
+
+    beforeEach(function () {
+        bust = new CacheBuster();
+    });
+
+    describe('for buffer files', function () {
+
+        it('Should produce different checksums for different content.', function () {
+            var file1 = createBufferFile('file1', 'content1');
+            var file2 = createBufferFile('file2', 'content2');
+            var checksum1 = bust.getChecksum(file1);
+            var checksum2 = bust.getChecksum(file2);
+            //console.log('checksum1: ' + checksum1);
+            //console.log('checksum2: ' + checksum2);
+            // Sanity checks
+            expect(file1.isBuffer()).to.be.true;
+            expect(file2.isBuffer()).to.be.true;
+            expect(file1.isStream()).to.be.false;
+            expect(file2.isStream()).to.be.false;
+            // The test
+            expect(checksum1).to.not.equal(checksum2);
+        });
+    });
+
+    describe('for stream files', function () {
+        it('Should produce different checksums for different content.', function () {
+            var file1 = createStreamFile('file1', 'content1');
+            var file2 = createStreamFile('file2', 'content2');
+            var checksum1 = bust.getChecksum(file1);
+            var checksum2 = bust.getChecksum(file2);
+            //console.log('checksum1: ' + checksum1);
+            //console.log('checksum2: ' + checksum2);
+            // Sanity checks
+            expect(file1.isBuffer()).to.be.false;
+            expect(file2.isBuffer()).to.be.false;
+            expect(file1.isStream()).to.be.true;
+            expect(file2.isStream()).to.be.true;
+            // The test
+            expect(checksum1).to.not.equal(checksum2);
+        });
+    });
+});
+
+
+
+
+
+

--- a/test/pathbust.js
+++ b/test/pathbust.js
@@ -1,0 +1,45 @@
+var CacheBuster = require('../index');
+var File = require('vinyl');
+var expect = require('chai').expect;
+
+function createFile(cwd, base, path, filename) {
+    var contentBuffer = new Buffer('foo');
+    return new File({
+          cwd: cwd,
+          base: base,
+          path: path + '/' + filename,
+          contents: contentBuffer
+    });
+}
+
+describe('path buster', function () {
+    var bust;
+
+    beforeEach(function () {
+        bust = new CacheBuster();
+    });
+
+    describe('with checksum', function () {
+
+        it('should return the full path with checksum', function () {
+            bust.getChecksum = function () {
+                return '123';
+            };
+            var fullPath = bust.getBustedPath(createFile('/cwd', 'base', 'folder', 'file.test'));
+            expect(fullPath).to.equal('folder/file.123.test');
+        });
+    });
+
+    describe('with random hash', function () {
+        it('should return the full path with checksum', function () {
+            bust.random = true;
+            bust.hash = '234';
+            var fullPath = bust.getBustedPath(createFile('/cwd', 'base', 'folder', 'file.test'));
+            expect(fullPath).to.equal('folder/file.234.test');
+        });
+    });
+});
+
+
+
+

--- a/test/pathbust.js
+++ b/test/pathbust.js
@@ -1,3 +1,4 @@
+/*jshint mocha:true, expr: true */
 var CacheBuster = require('../index');
 var File = require('vinyl');
 var expect = require('chai').expect;

--- a/test/relativemappings.js
+++ b/test/relativemappings.js
@@ -1,0 +1,27 @@
+var CacheBuster = require('../index');
+var File = require('vinyl');
+var expect = require('chai').expect;
+var _ = require('lodash');
+
+describe('relative mappings', function () {
+    var bust;
+
+    beforeEach(function () {
+        bust = new CacheBuster();
+    });
+
+    it('should convert the mappmings hash to an array of objects', function () {
+        debugger
+        bust.mappings = {
+            orig1: 'busted1',
+            orig2: 'busted2',
+            orig3: 'busted3'
+        };
+        var relativeMappings = bust.getRelativeMappings();
+        expect(_.find(relativeMappings, function (o) { return o.original === 'orig1' && o.cachebusted === 'busted1';})).to.be.ok;
+        expect(_.find(relativeMappings, function (o) { return o.original === 'orig2' && o.cachebusted === 'busted2';})).to.be.ok;
+        expect(_.find(relativeMappings, function (o) { return o.original === 'orig3' && o.cachebusted === 'busted3';})).to.be.ok;
+    });
+});
+
+

--- a/test/relativemappings.js
+++ b/test/relativemappings.js
@@ -1,3 +1,4 @@
+/*jshint mocha:true, expr: true */
 var CacheBuster = require('../index');
 var File = require('vinyl');
 var expect = require('chai').expect;
@@ -11,7 +12,6 @@ describe('relative mappings', function () {
     });
 
     it('should convert the mappmings hash to an array of objects', function () {
-        debugger
         bust.mappings = {
             orig1: 'busted1',
             orig2: 'busted2',


### PR DESCRIPTION
Thanks for this awesome easy-to-use cachbusting plugin! I found that the hash generated for a browserify-bundled run through vinyl-source always was the same, and traced it to your hash-generating method always yielding the same hash for stream-based files (working fine for buffer-based files). I've made a unit test demonstrating the problem, and also wrote some quick tests for some of the other methods, as I believe having better test coverage would make it easier for others to contribute to the project (and also trust in it). I haven't done much research on how to correct the issue, as for me, a workaround of piping the stream through gulp-buffer was good enough, but my first thought is you could use the hash of the content instead of the file-object itself. Anyway, I hope you can find this useful. 